### PR TITLE
[all] Replace all instances of step with task

### DIFF
--- a/client/src/task_sharding_client/client.py
+++ b/client/src/task_sharding_client/client.py
@@ -126,7 +126,7 @@ class Client:
             "message_type": MessageType.TASK_COMPLETE,
             "schema_id": self._schema["name"],
             "task_id": task_id,
-            "step_success": bool(True if self._task_return_code == 0 else False),
+            "task_success": bool(True if self._task_return_code == 0 else False),
         }
 
         logger.info("Sending task complete message: %s", str(task_message))

--- a/client/src/task_sharding_client/client.py
+++ b/client/src/task_sharding_client/client.py
@@ -60,7 +60,7 @@ class Client:
             "complex_patchset": self._complex_patchset,
             "cache_id": self._config.cache_id,
             "schema_id": self._schema["name"],
-            "total_steps": len(self._schema["steps"]),
+            "total_steps": len(self._schema["tasks"]),
         }
 
         logger.info("Sending initial message: %s", str(initial_message))

--- a/client/src/task_sharding_client/client.py
+++ b/client/src/task_sharding_client/client.py
@@ -60,7 +60,7 @@ class Client:
             "complex_patchset": self._complex_patchset,
             "cache_id": self._config.cache_id,
             "schema_id": self._schema["name"],
-            "total_steps": len(self._schema["tasks"]),
+            "total_tasks": len(self._schema["tasks"]),
         }
 
         logger.info("Sending initial message: %s", str(initial_message))
@@ -114,7 +114,7 @@ class Client:
         This method starts the task runner and passes to it a task ID.
         """
 
-        task_id = msg["step_id"]
+        task_id = msg["task_id"]
 
         # Run the task (BLOCKING)
         self._task_return_code = self._task_runner_instance.run(task_id)
@@ -125,7 +125,7 @@ class Client:
         task_message = {
             "message_type": MessageType.TASK_COMPLETE,
             "schema_id": self._schema["name"],
-            "step_id": task_id,
+            "task_id": task_id,
             "step_success": bool(True if self._task_return_code == 0 else False),
         }
 

--- a/client/src/task_sharding_client/message_type.py
+++ b/client/src/task_sharding_client/message_type.py
@@ -4,7 +4,7 @@ import enum
 class MessageType(int, enum.Enum):
     INIT = 1
     BUILD_INSTRUCTION = 2
-    STEP_COMPLETE = 3
+    TASK_COMPLETE = 3
     SCHEMA_COMPLETE = 4
-    ABORT_STEP = 5
+    ABORT_TASK = 5
     WEBSOCKET_CLOSED = 6

--- a/client/src/task_sharding_client/task_runner.py
+++ b/client/src/task_sharding_client/task_runner.py
@@ -9,7 +9,7 @@ class TaskRunner:
     def __exit__(self, exc_type, exc_value, traceback):
         self.abort()
 
-    def run(self, step_id: str) -> int:
+    def run(self, task_id: str) -> int:
         raise NotImplementedError()
 
     def abort(self):

--- a/client/test/data/test_schema.yaml
+++ b/client/test/data/test_schema.yaml
@@ -1,5 +1,5 @@
 name: mock_schema
-steps:
+tasks:
   - task: 2
   - task: 3
   - task: 4

--- a/client/test/test_client.py
+++ b/client/test/test_client.py
@@ -147,7 +147,7 @@ class TestClient(unittest.TestCase):
         GIVEN a client connected to the server with a designated schema.
         WHEN the client receives build instructions,
           AND subsequently fails to complete those build instructions.
-        EXPECT client to send a failed step complete message
+        EXPECT client to send a failed task complete message
           AND disconnect.
         """
         repo_state = {

--- a/client/test/test_client.py
+++ b/client/test/test_client.py
@@ -74,7 +74,7 @@ class TestClient(unittest.TestCase):
         GIVEN a client connected to the server with a designated schema.
         WHEN the client receives build instructions,
           AND subsequently successfully completes those build instructions.
-        EXPECT client to send a successful step complete message
+        EXPECT client to send a successful task complete message
           AND receive a schema complete message and disconnect.
         """
         repo_state = {
@@ -103,8 +103,8 @@ class TestClient(unittest.TestCase):
                 )
             )
 
-            # Get step_complete message from client (BLOCKING)
-            step_complete_msg = connection.get_sent_msg()
+            # Get task_complete message from client (BLOCKING)
+            task_complete_msg = connection.get_sent_msg()
 
             # Mock schema complete message from server
             connection._received_messages.put(
@@ -139,7 +139,7 @@ class TestClient(unittest.TestCase):
                     "task_id": "0",
                     "task_success": True,
                 },
-                step_complete_msg,
+                task_complete_msg,
             )
 
     def test__when_a_client_connects_to_the_server__and_the_build_task_fails__expect_client_to_disconnect(self):
@@ -176,8 +176,8 @@ class TestClient(unittest.TestCase):
                 )
             )
 
-            # Get step_complete message from client (BLOCKING)
-            step_complete_msg = connection.get_sent_msg()
+            # Get task_complete message from client (BLOCKING)
+            task_complete_msg = connection.get_sent_msg()
 
             # Join the client thread (Assert that the client's infinite message receiving loop ends)
             client_thread.join()
@@ -202,7 +202,7 @@ class TestClient(unittest.TestCase):
                     "task_id": "0",
                     "task_success": False,
                 },
-                step_complete_msg,
+                task_complete_msg,
             )
 
     def test__when_a_client_connects_to_the_server__and_server_sends_a_websocket_close_message__expect_that_the_build_task_is_aborted_and_the_websocket_is_closed(

--- a/client/test/test_client.py
+++ b/client/test/test_client.py
@@ -98,7 +98,7 @@ class TestClient(unittest.TestCase):
                     {
                         "message_type": MessageType.BUILD_INSTRUCTION,
                         "schema_id": "mock_schema",
-                        "step_id": "0",
+                        "task_id": "0",
                     }
                 )
             )
@@ -111,7 +111,7 @@ class TestClient(unittest.TestCase):
                 json.dumps(
                     {
                         "message_type": MessageType.SCHEMA_COMPLETE,
-                        "schema_id": "mock_schema",
+                        "task_id": "mock_schema",
                     }
                 )
             )
@@ -128,7 +128,7 @@ class TestClient(unittest.TestCase):
                     "complex_patchset": False,
                     "cache_id": "1",
                     "schema_id": "mock_schema",
-                    "total_steps": 4,
+                    "total_tasks": 4,
                 },
                 init_msg,
             )
@@ -136,7 +136,7 @@ class TestClient(unittest.TestCase):
                 {
                     "message_type": MessageType.TASK_COMPLETE,
                     "schema_id": "mock_schema",
-                    "step_id": "0",
+                    "task_id": "0",
                     "step_success": True,
                 },
                 step_complete_msg,
@@ -171,7 +171,7 @@ class TestClient(unittest.TestCase):
                     {
                         "message_type": MessageType.BUILD_INSTRUCTION,
                         "schema_id": "mock_schema",
-                        "step_id": "0",
+                        "task_id": "0",
                     }
                 )
             )
@@ -191,7 +191,7 @@ class TestClient(unittest.TestCase):
                     "complex_patchset": False,
                     "cache_id": "1",
                     "schema_id": "mock_schema",
-                    "total_steps": 4,
+                    "total_tasks": 4,
                 },
                 init_msg,
             )
@@ -199,7 +199,7 @@ class TestClient(unittest.TestCase):
                 {
                     "message_type": MessageType.TASK_COMPLETE,
                     "schema_id": "mock_schema",
-                    "step_id": "0",
+                    "task_id": "0",
                     "step_success": False,
                 },
                 step_complete_msg,
@@ -235,7 +235,7 @@ class TestClient(unittest.TestCase):
                     {
                         "message_type": MessageType.BUILD_INSTRUCTION,
                         "schema_id": "mock_schema",
-                        "step_id": "0",
+                        "task_id": "0",
                     }
                 )
             )
@@ -260,7 +260,7 @@ class TestClient(unittest.TestCase):
                     "complex_patchset": False,
                     "cache_id": "1",
                     "schema_id": "mock_schema",
-                    "total_steps": 4,
+                    "total_tasks": 4,
                 },
                 init_msg,
             )

--- a/client/test/test_client.py
+++ b/client/test/test_client.py
@@ -137,7 +137,7 @@ class TestClient(unittest.TestCase):
                     "message_type": MessageType.TASK_COMPLETE,
                     "schema_id": "mock_schema",
                     "task_id": "0",
-                    "step_success": True,
+                    "task_success": True,
                 },
                 step_complete_msg,
             )
@@ -200,7 +200,7 @@ class TestClient(unittest.TestCase):
                     "message_type": MessageType.TASK_COMPLETE,
                     "schema_id": "mock_schema",
                     "task_id": "0",
-                    "step_success": False,
+                    "task_success": False,
                 },
                 step_complete_msg,
             )

--- a/client/test/test_client.py
+++ b/client/test/test_client.py
@@ -28,9 +28,9 @@ class MockConnection(Connection):
 
 
 class MockSuccessfulTaskRunner(TaskRunner):
-    def run(self, step_id: str) -> int:
-        logger.info("Starting task: %s", step_id)
-        logger.info("Finished task: %s", step_id)
+    def run(self, task_id: str) -> int:
+        logger.info("Starting task: %s", task_id)
+        logger.info("Finished task: %s", task_id)
         return 0
 
     def abort(self):
@@ -38,9 +38,9 @@ class MockSuccessfulTaskRunner(TaskRunner):
 
 
 class MockFailedTaskRunner(TaskRunner):
-    def run(self, step_id: str) -> int:
-        logger.info("Starting task: %s", step_id)
-        logger.info("Finished task: %s", step_id)
+    def run(self, task_id: str) -> int:
+        logger.info("Starting task: %s", task_id)
+        logger.info("Finished task: %s", task_id)
         return 1
 
     def abort(self):
@@ -52,7 +52,7 @@ class MockRunUntilAbortedRunner(TaskRunner):
         super().__init__(schema, config)
         self._run_loop = True
 
-    def run(self, step_id: str) -> int:
+    def run(self, task_id: str) -> int:
         while self._run_loop:
             continue
         return 1
@@ -134,7 +134,7 @@ class TestClient(unittest.TestCase):
             )
             self.assertDictEqual(
                 {
-                    "message_type": MessageType.STEP_COMPLETE,
+                    "message_type": MessageType.TASK_COMPLETE,
                     "schema_id": "mock_schema",
                     "step_id": "0",
                     "step_success": True,
@@ -197,7 +197,7 @@ class TestClient(unittest.TestCase):
             )
             self.assertDictEqual(
                 {
-                    "message_type": MessageType.STEP_COMPLETE,
+                    "message_type": MessageType.TASK_COMPLETE,
                     "schema_id": "mock_schema",
                     "step_id": "0",
                     "step_success": False,

--- a/examples/bazel/main.py
+++ b/examples/bazel/main.py
@@ -19,7 +19,7 @@ class BazelTask(TaskRunner):
     def run(self, task_id: str) -> int:
         logger.info("Starting build task")
 
-        target = self._schema["steps"][int(task_id)]["task"]
+        target = self._schema["tasks"][int(task_id)]["task"]
         self._process = subprocess.Popen(["bazel", "test", target], cwd=self._config.workspace_path)
         stdout, stderr = self._process.communicate()
         exit_code = self._process.wait()

--- a/examples/bazel/main.py
+++ b/examples/bazel/main.py
@@ -16,10 +16,10 @@ class BazelTask(TaskRunner):
         super().__init__(schema, config)
         self._process = None
 
-    def run(self, step_id: str) -> int:
+    def run(self, task_id: str) -> int:
         logger.info("Starting build task")
 
-        target = self._schema["steps"][int(step_id)]["task"]
+        target = self._schema["steps"][int(task_id)]["task"]
         self._process = subprocess.Popen(["bazel", "test", target], cwd=self._config.workspace_path)
         stdout, stderr = self._process.communicate()
         exit_code = self._process.wait()

--- a/examples/bazel/schema.yaml
+++ b/examples/bazel/schema.yaml
@@ -1,5 +1,5 @@
 name: bazel
-steps:
+tasks:
   - task: //:test_my_script_1
   - task: //:test_my_script_2
   - task: //:test_my_script_3

--- a/examples/sleep/main.py
+++ b/examples/sleep/main.py
@@ -14,7 +14,7 @@ class SleepTask(TaskRunner):
     def run(self, task_id: str) -> int:
         logger.info("Starting build task")
 
-        sleep_amount = self._schema["steps"][int(task_id)]["task"]
+        sleep_amount = self._schema["tasks"][int(task_id)]["task"]
         sleep(sleep_amount)
 
         logger.info("Finished build task")

--- a/examples/sleep/main.py
+++ b/examples/sleep/main.py
@@ -11,10 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 class SleepTask(TaskRunner):
-    def run(self, step_id: str) -> int:
+    def run(self, task_id: str) -> int:
         logger.info("Starting build task")
 
-        sleep_amount = self._schema["steps"][int(step_id)]["task"]
+        sleep_amount = self._schema["steps"][int(task_id)]["task"]
         sleep(sleep_amount)
 
         logger.info("Finished build task")

--- a/examples/sleep/schema.yaml
+++ b/examples/sleep/schema.yaml
@@ -1,5 +1,5 @@
 name: sleep
-steps:
+tasks:
   - task: 2
   - task: 3
   - task: 4

--- a/server/task_sharding/src/controller.py
+++ b/server/task_sharding/src/controller.py
@@ -94,7 +94,7 @@ class Controller(AsyncConsumer):
             return self._create_schema_instance(msg)
 
     def _create_schema_instance(self, msg: dict) -> SchemaInstance:
-        schema_details = SchemaDetails(msg["cache_id"], msg["schema_id"], msg["total_steps"])
+        schema_details = SchemaDetails(msg["cache_id"], msg["schema_id"], msg["total_tasks"])
         logger.info("Creating schema instance with ID: %s", schema_details.id)
         schema_instance = SchemaInstance(schema_details)
         self._schema_instances.append(schema_instance)

--- a/server/task_sharding/src/message_type.py
+++ b/server/task_sharding/src/message_type.py
@@ -4,5 +4,7 @@ import enum
 class MessageType(int, enum.Enum):
     INIT = 1
     BUILD_INSTRUCTION = 2
-    STEP_COMPLETE = 3
+    TASK_COMPLETE = 3
     SCHEMA_COMPLETE = 4
+    ABORT_TASK = 5
+    WEBSOCKET_CLOSED = 6

--- a/server/task_sharding/src/schema_details.py
+++ b/server/task_sharding/src/schema_details.py
@@ -2,8 +2,8 @@ import uuid
 
 
 class SchemaDetails:
-    def __init__(self, cache_id: str, schema_id: str, total_steps: int) -> None:
+    def __init__(self, cache_id: str, schema_id: str, total_tasks: int) -> None:
         self.cache_id = cache_id
         self.schema_id = schema_id
-        self.total_steps = total_steps
+        self.total_tasks = total_tasks
         self.id = str(uuid.uuid4())

--- a/server/task_sharding/src/schema_instance.py
+++ b/server/task_sharding/src/schema_instance.py
@@ -110,9 +110,9 @@ class SchemaInstance:
     async def _receive_step_completed(self, msg: dict, consumer_id: str):
         with self._consumer_lock:
             task_id = msg["task_id"]
-            step_success = msg["step_success"]
+            task_success = msg["task_success"]
             del self._in_progress_consumers[consumer_id]
-            if step_success:
+            if task_success:
                 self._print_with_prefix("Consumer " + consumer_id + " completed step " + task_id)
             else:
                 # TODO: Do something on a step failure

--- a/server/task_sharding/src/schema_instance.py
+++ b/server/task_sharding/src/schema_instance.py
@@ -35,10 +35,10 @@ class SchemaInstance:
             if consumer_id in self._registered_consumers:
                 self._registered_consumers.remove(consumer_id)
             if consumer_id in self._in_progress_consumers:
-                step_id = self._in_progress_consumers[consumer_id]
+                task_id = self._in_progress_consumers[consumer_id]
                 del self._in_progress_consumers[consumer_id]
-                self._to_do_steps.append(step_id)
-                self._print_with_prefix("Unassigning step ID " + str(step_id) + " from consumer " + consumer_id)
+                self._to_do_steps.append(task_id)
+                self._print_with_prefix("Unassigning task ID " + str(task_id) + " from consumer " + consumer_id)
             if consumer_id in self._repo_states:
                 del self._repo_states[consumer_id]
 
@@ -109,14 +109,14 @@ class SchemaInstance:
 
     async def _receive_step_completed(self, msg: dict, consumer_id: str):
         with self._consumer_lock:
-            step_id = msg["step_id"]
+            task_id = msg["step_id"]
             step_success = msg["step_success"]
             del self._in_progress_consumers[consumer_id]
             if step_success:
-                self._print_with_prefix("Consumer " + consumer_id + " completed step " + step_id)
+                self._print_with_prefix("Consumer " + consumer_id + " completed step " + task_id)
             else:
                 # TODO: Do something on a step failure
-                self._to_do_steps.append(int(step_id))
+                self._to_do_steps.append(int(task_id))
             steps_not_started = len(self._to_do_steps)
             steps_in_progress = len(self._in_progress_consumers)
 

--- a/server/task_sharding/src/schema_instance.py
+++ b/server/task_sharding/src/schema_instance.py
@@ -21,7 +21,7 @@ class SchemaInstance:
 
         self._dispatch = {
             MessageType.INIT: self._send_build_instructions,
-            MessageType.TASK_COMPLETE: self._receive_step_completed,
+            MessageType.TASK_COMPLETE: self._receive_task_completed,
         }
 
     def register_consumer(self, consumer_id: str, repo_state: dict):
@@ -107,7 +107,7 @@ class SchemaInstance:
                     },
                 )
 
-    async def _receive_step_completed(self, msg: dict, consumer_id: str):
+    async def _receive_task_completed(self, msg: dict, consumer_id: str):
         with self._consumer_lock:
             task_id = msg["task_id"]
             task_success = msg["task_success"]

--- a/server/task_sharding/src/schema_instance.py
+++ b/server/task_sharding/src/schema_instance.py
@@ -21,7 +21,7 @@ class SchemaInstance:
 
         self._dispatch = {
             MessageType.INIT: self._send_build_instructions,
-            MessageType.STEP_COMPLETE: self._receive_step_completed,
+            MessageType.TASK_COMPLETE: self._receive_step_completed,
         }
 
     def register_consumer(self, consumer_id: str, repo_state: dict):

--- a/server/task_sharding/src/schema_instance.py
+++ b/server/task_sharding/src/schema_instance.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class SchemaInstance:
     def __init__(self, schema_details: SchemaDetails):
         self.schema_details = schema_details
-        self._to_do_steps = list(range(0, self.schema_details.total_steps))
+        self._to_do_steps = list(range(0, self.schema_details.total_tasks))
         self._channel_layer = get_channel_layer()
 
         self._registered_consumers = set()
@@ -103,13 +103,13 @@ class SchemaInstance:
                         "type": "send.message",
                         "message_type": MessageType.BUILD_INSTRUCTION,
                         "schema_id": self.schema_details.schema_id,
-                        "step_id": str(step),
+                        "task_id": str(step),
                     },
                 )
 
     async def _receive_step_completed(self, msg: dict, consumer_id: str):
         with self._consumer_lock:
-            task_id = msg["step_id"]
+            task_id = msg["task_id"]
             step_success = msg["step_success"]
             del self._in_progress_consumers[consumer_id]
             if step_success:

--- a/server/task_sharding/test/defaults.py
+++ b/server/task_sharding/test/defaults.py
@@ -12,7 +12,7 @@ def create_application():
     )
 
 
-def create_default_client_init_message(total_steps=1):
+def create_default_client_init_message(total_tasks=1):
     return {
         "message_type": MessageType.INIT,
         "repo_state": {
@@ -23,7 +23,7 @@ def create_default_client_init_message(total_steps=1):
         },
         "complex_patchset": False,
         "cache_id": "1",
-        "total_steps": total_steps,
+        "total_tasks": total_tasks,
         "schema_id": "1",
     }
 
@@ -33,7 +33,7 @@ def create_default_build_instruction_message(task_id="0"):
         "type": "send.message",
         "message_type": MessageType.BUILD_INSTRUCTION,
         "schema_id": "1",
-        "step_id": task_id,
+        "task_id": task_id,
     }
 
 
@@ -41,7 +41,7 @@ def create_default_step_complete_message(task_id="0", step_success=True):
     return {
         "message_type": MessageType.TASK_COMPLETE,
         "schema_id": "1",
-        "step_id": task_id,
+        "task_id": task_id,
         "step_success": step_success,
     }
 

--- a/server/task_sharding/test/defaults.py
+++ b/server/task_sharding/test/defaults.py
@@ -37,7 +37,7 @@ def create_default_build_instruction_message(task_id="0"):
     }
 
 
-def create_default_step_complete_message(task_id="0", task_success=True):
+def create_default_task_complete_message(task_id="0", task_success=True):
     return {
         "message_type": MessageType.TASK_COMPLETE,
         "schema_id": "1",

--- a/server/task_sharding/test/defaults.py
+++ b/server/task_sharding/test/defaults.py
@@ -28,20 +28,20 @@ def create_default_client_init_message(total_steps=1):
     }
 
 
-def create_default_build_instruction_message(step_id="0"):
+def create_default_build_instruction_message(task_id="0"):
     return {
         "type": "send.message",
         "message_type": MessageType.BUILD_INSTRUCTION,
         "schema_id": "1",
-        "step_id": step_id,
+        "step_id": task_id,
     }
 
 
-def create_default_step_complete_message(step_id="0", step_success=True):
+def create_default_step_complete_message(task_id="0", step_success=True):
     return {
         "message_type": MessageType.STEP_COMPLETE,
         "schema_id": "1",
-        "step_id": step_id,
+        "step_id": task_id,
         "step_success": step_success,
     }
 

--- a/server/task_sharding/test/defaults.py
+++ b/server/task_sharding/test/defaults.py
@@ -37,12 +37,12 @@ def create_default_build_instruction_message(task_id="0"):
     }
 
 
-def create_default_step_complete_message(task_id="0", step_success=True):
+def create_default_step_complete_message(task_id="0", task_success=True):
     return {
         "message_type": MessageType.TASK_COMPLETE,
         "schema_id": "1",
         "task_id": task_id,
-        "step_success": step_success,
+        "task_success": task_success,
     }
 
 

--- a/server/task_sharding/test/defaults.py
+++ b/server/task_sharding/test/defaults.py
@@ -39,7 +39,7 @@ def create_default_build_instruction_message(task_id="0"):
 
 def create_default_step_complete_message(task_id="0", step_success=True):
     return {
-        "message_type": MessageType.STEP_COMPLETE,
+        "message_type": MessageType.TASK_COMPLETE,
         "schema_id": "1",
         "step_id": task_id,
         "step_success": step_success,

--- a/server/task_sharding/test/test_schema_complete.py
+++ b/server/task_sharding/test/test_schema_complete.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from task_sharding.test.defaults import (
     create_application,
     create_default_client_init_message,
-    create_default_step_complete_message,
+    create_default_task_complete_message,
     create_default_schema_complete_message,
 )
 from task_sharding.test.utils import (
@@ -33,7 +33,7 @@ class TaskShardingTests__SchemaCompleted(TestCase):
         await consumer_1.connect()
 
         client_init_msg = create_default_client_init_message()
-        client_step_complete_msg = create_default_step_complete_message()
+        client_task_complete_msg = create_default_task_complete_message()
         expected_schema_complete_msg = create_default_schema_complete_message()
 
         # Send client init message to controller
@@ -49,7 +49,7 @@ class TaskShardingTests__SchemaCompleted(TestCase):
         self.assertEqual(1, total_running_schema_instances)
 
         # Send client step complete message to controller
-        await send_message_between_communicators(consumer_1, controller, client_step_complete_msg)
+        await send_message_between_communicators(consumer_1, controller, client_task_complete_msg)
 
         # Assert the controller sent the correct schema complete message to the consumer
         actual_schema_complete_msg = await consumer_1.receive_from()
@@ -80,7 +80,7 @@ class TaskShardingTests__SchemaCompleted(TestCase):
         self.assertEqual(1, total_running_schema_instances)
 
         # Send client step complete message to controller
-        await send_message_between_communicators(consumer_2, controller, client_step_complete_msg)
+        await send_message_between_communicators(consumer_2, controller, client_task_complete_msg)
 
         # Assert the controller sent the correct schema complete message to the consumer
         actual_schema_complete_msg = await consumer_2.receive_from()

--- a/server/task_sharding/test/test_schema_complete.py
+++ b/server/task_sharding/test/test_schema_complete.py
@@ -48,7 +48,7 @@ class TaskShardingTests__SchemaCompleted(TestCase):
         )
         self.assertEqual(1, total_running_schema_instances)
 
-        # Send client step complete message to controller
+        # Send client task complete message to controller
         await send_message_between_communicators(consumer_1, controller, client_task_complete_msg)
 
         # Assert the controller sent the correct schema complete message to the consumer
@@ -79,7 +79,7 @@ class TaskShardingTests__SchemaCompleted(TestCase):
         )
         self.assertEqual(1, total_running_schema_instances)
 
-        # Send client step complete message to controller
+        # Send client task complete message to controller
         await send_message_between_communicators(consumer_2, controller, client_task_complete_msg)
 
         # Assert the controller sent the correct schema complete message to the consumer

--- a/server/task_sharding/test/test_schema_init.py
+++ b/server/task_sharding/test/test_schema_init.py
@@ -10,7 +10,7 @@ from task_sharding.test.utils import proxy_message_from_channel_to_communicator,
 
 
 def create_client_init_message_default(
-    repo_state=None, complex_patchset=False, cache_id="1", schema_id="1", total_steps=1
+    repo_state=None, complex_patchset=False, cache_id="1", schema_id="1", total_tasks=1
 ) -> dict:
     if not repo_state:
         repo_state = {
@@ -25,7 +25,7 @@ def create_client_init_message_default(
         "complex_patchset": complex_patchset,
         "cache_id": cache_id,
         "schema_id": schema_id,
-        "total_steps": total_steps,
+        "total_tasks": total_tasks,
     }
 
 

--- a/server/task_sharding/test/test_schema_step_complete.py
+++ b/server/task_sharding/test/test_schema_step_complete.py
@@ -16,7 +16,7 @@ from task_sharding.test.utils import (
 )
 
 
-class TaskShardingTests__SingleConsumerStepComplete(TestCase):
+class TaskShardingTests__SingleConsumerTaskComplete(TestCase):
     async def setUpAsync(self):
         application = create_application()
         self.controller = ApplicationCommunicator(application, {"type": "channel", "channel": "controller"})
@@ -27,14 +27,14 @@ class TaskShardingTests__SingleConsumerStepComplete(TestCase):
         await self.consumer.disconnect()
         await proxy_message_from_channel_to_communicator("controller", self.controller)
 
-    async def test__when_one_consumer_connected__and_single_schema_step_is_successful__expect_schema_complete_msg_sent(
+    async def test__when_one_consumer_connected__and_single_schema_task_is_successful__expect_schema_complete_msg_sent(
         self,
     ):
         """
         GIVEN a freshly instantiated TaskShardingController.
-        WHEN a consumer connects and sends an INIT message with a single step,
+        WHEN a consumer connects and sends an INIT message with a single task,
           AND the server sends a build instruction message to the consumer,
-          AND the consumer subsequently sends a successful step complete message.
+          AND the consumer subsequently sends a successful task complete message.
         EXPECT the server to return to the same consumer a schema complete message.
         """
 
@@ -60,13 +60,13 @@ class TaskShardingTests__SingleConsumerStepComplete(TestCase):
 
         await self.tearDownAsync()
 
-    async def test__when_one_consumer_connected__and_multi_step_schema_is_successful__expect_schema_complete_msg_sent(
+    async def test__when_one_consumer_connected__and_multi_task_schema_is_successful__expect_schema_complete_msg_sent(
         self,
     ):
         """
         GIVEN a freshly instantiated TaskShardingController.
-        WHEN a consumer connects and sends an INIT message with multiple steps,
-          AND the consumer subsequently sends multiple successful step complete messages.
+        WHEN a consumer connects and sends an INIT message with multiple tasks,
+          AND the consumer subsequently sends multiple successful task complete messages.
         EXPECT the server to return to the same consumer a schema complete message.
         """
 
@@ -81,18 +81,18 @@ class TaskShardingTests__SingleConsumerStepComplete(TestCase):
         actual_build_instruction_msg = await self.consumer.receive_from()
         self.assertDictEqual(expected_build_instruction_1_msg, json.loads(actual_build_instruction_msg))
 
-        # Send client step complete message to controller
-        client_step_1_complete_msg = create_default_task_complete_message("1")
-        await send_message_between_communicators(self.consumer, self.controller, client_step_1_complete_msg)
+        # Send client task complete message to controller
+        client_task_1_complete_msg = create_default_task_complete_message("1")
+        await send_message_between_communicators(self.consumer, self.controller, client_task_1_complete_msg)
 
         # Assert the controller sent the correct build instruction to the consumer
         expected_build_instruction_2_msg = create_default_build_instruction_message("0")
         actual_build_instruction_msg = await self.consumer.receive_from()
         self.assertDictEqual(expected_build_instruction_2_msg, json.loads(actual_build_instruction_msg))
 
-        # Send client step complete message to controller
-        client_step_2_complete_msg = create_default_task_complete_message("0")
-        await send_message_between_communicators(self.consumer, self.controller, client_step_2_complete_msg)
+        # Send client task complete message to controller
+        client_task_2_complete_msg = create_default_task_complete_message("0")
+        await send_message_between_communicators(self.consumer, self.controller, client_task_2_complete_msg)
 
         # Assert the controller sent the correct schema complete message to the consumer
         expected_schema_complete_msg = create_default_schema_complete_message()
@@ -102,7 +102,7 @@ class TaskShardingTests__SingleConsumerStepComplete(TestCase):
         await self.tearDownAsync()
 
 
-class TaskShardingTests__TwoConsumersStepComplete(TestCase):
+class TaskShardingTests__TwoConsumersTaskComplete(TestCase):
     async def setUpAsync(self):
         application = create_application()
         self.controller = ApplicationCommunicator(application, {"type": "channel", "channel": "controller"})
@@ -117,14 +117,14 @@ class TaskShardingTests__TwoConsumersStepComplete(TestCase):
         await self.consumer2.disconnect()
         await proxy_message_from_channel_to_communicator("controller", self.controller)
 
-    async def test__when_two_consumers_connected__and_both_schema_steps_are_successful__expect_schema_complete_msg_sent(
+    async def test__when_two_consumers_connected__and_both_schema_tasks_are_successful__expect_schema_complete_msg_sent(
         self,
     ):
         """
         GIVEN a freshly instantiated TaskShardingController.
-        WHEN two consumers connect and send an INIT message with the same config and two steps,
+        WHEN two consumers connect and send an INIT message with the same config and two tasks,
           AND the server sends a different build instruction message to each consumer,
-          AND the consumers subsequently send a successful step complete message.
+          AND the consumers subsequently send a successful task complete message.
         EXPECT the server to return to both consumers a schema complete message.
         """
 

--- a/server/task_sharding/test/test_schema_step_complete.py
+++ b/server/task_sharding/test/test_schema_step_complete.py
@@ -7,7 +7,7 @@ from task_sharding.test.defaults import (
     create_application,
     create_default_client_init_message,
     create_default_build_instruction_message,
-    create_default_step_complete_message,
+    create_default_task_complete_message,
     create_default_schema_complete_message,
 )
 from task_sharding.test.utils import (
@@ -49,9 +49,9 @@ class TaskShardingTests__SingleConsumerStepComplete(TestCase):
         actual_build_instruction_msg = await self.consumer.receive_from()
         self.assertDictEqual(expected_build_instruction_msg, json.loads(actual_build_instruction_msg))
 
-        # Send step complete message to controller
-        client_step_complete_msg = create_default_step_complete_message()
-        await send_message_between_communicators(self.consumer, self.controller, client_step_complete_msg)
+        # Send task complete message to controller
+        client_task_complete_msg = create_default_task_complete_message()
+        await send_message_between_communicators(self.consumer, self.controller, client_task_complete_msg)
 
         # Assert the controller sent the correct schema complete message to the consumer
         expected_schema_complete_msg = create_default_schema_complete_message()
@@ -82,7 +82,7 @@ class TaskShardingTests__SingleConsumerStepComplete(TestCase):
         self.assertDictEqual(expected_build_instruction_1_msg, json.loads(actual_build_instruction_msg))
 
         # Send client step complete message to controller
-        client_step_1_complete_msg = create_default_step_complete_message("1")
+        client_step_1_complete_msg = create_default_task_complete_message("1")
         await send_message_between_communicators(self.consumer, self.controller, client_step_1_complete_msg)
 
         # Assert the controller sent the correct build instruction to the consumer
@@ -91,7 +91,7 @@ class TaskShardingTests__SingleConsumerStepComplete(TestCase):
         self.assertDictEqual(expected_build_instruction_2_msg, json.loads(actual_build_instruction_msg))
 
         # Send client step complete message to controller
-        client_step_2_complete_msg = create_default_step_complete_message("0")
+        client_step_2_complete_msg = create_default_task_complete_message("0")
         await send_message_between_communicators(self.consumer, self.controller, client_step_2_complete_msg)
 
         # Assert the controller sent the correct schema complete message to the consumer
@@ -147,13 +147,13 @@ class TaskShardingTests__TwoConsumersStepComplete(TestCase):
         actual_build_instruction_msg = await self.consumer2.receive_from()
         self.assertDictEqual(expected_client_2_build_instruction_msg, json.loads(actual_build_instruction_msg))
 
-        # Send client step complete message to controller
-        client_1_step_complete_msg = create_default_step_complete_message("0")
-        await send_message_between_communicators(self.consumer1, self.controller, client_1_step_complete_msg)
+        # Send client task complete message to controller
+        client_1_task_complete_msg = create_default_task_complete_message("0")
+        await send_message_between_communicators(self.consumer1, self.controller, client_1_task_complete_msg)
 
-        # Send client step complete message to controller
-        client_2_step_complete_msg = create_default_step_complete_message("1")
-        await send_message_between_communicators(self.consumer2, self.controller, client_2_step_complete_msg)
+        # Send client task complete message to controller
+        client_2_task_complete_msg = create_default_task_complete_message("1")
+        await send_message_between_communicators(self.consumer2, self.controller, client_2_task_complete_msg)
 
         # Assert the controller sent the correct schema complete message to the consumer
         expected_schema_complete_msg = create_default_schema_complete_message()

--- a/server/task_sharding/test/test_schema_step_failed.py
+++ b/server/task_sharding/test/test_schema_step_failed.py
@@ -7,7 +7,7 @@ from task_sharding.test.defaults import (
     create_application,
     create_default_client_init_message,
     create_default_build_instruction_message,
-    create_default_step_complete_message,
+    create_default_task_complete_message,
 )
 from task_sharding.test.utils import (
     proxy_message_from_channel_to_communicator,
@@ -49,9 +49,9 @@ class TaskShardingTests__SingleConsumerStepFailed(TestCase):
         actual_build_instruction_msg = await self.consumer.receive_from()
         self.assertDictEqual(expected_build_instruction_msg, json.loads(actual_build_instruction_msg))
 
-        # Send step failed to controller
-        client_step_complete_msg = create_default_step_complete_message(0, False)
-        await send_message_between_communicators(self.consumer, self.controller, client_step_complete_msg)
+        # Send task failed to controller
+        client_task_complete_msg = create_default_task_complete_message(0, False)
+        await send_message_between_communicators(self.consumer, self.controller, client_task_complete_msg)
 
         # Assert the controller sent the correct build instruction to the consumer
         actual_build_instruction_msg = await self.consumer.receive_from()
@@ -145,9 +145,9 @@ class TaskShardingTests__MultipleConsumerStepAbandoned(TestCase):
         await self.consumer1.disconnect()
         await proxy_message_from_channel_to_communicator("controller", self.controller)
 
-        # Send step complete message to controller
-        step_2_step_complete_msg = create_default_step_complete_message()
-        await send_message_between_communicators(self.consumer2, self.controller, step_2_step_complete_msg)
+        # Send task complete message to controller
+        step_2_task_complete_msg = create_default_task_complete_message()
+        await send_message_between_communicators(self.consumer2, self.controller, step_2_task_complete_msg)
 
         # Assert the controller sent the correct build instruction to the consumer
         actual_build_instruction_msg = await self.consumer2.receive_from()

--- a/server/task_sharding/test/test_schema_step_failed.py
+++ b/server/task_sharding/test/test_schema_step_failed.py
@@ -16,7 +16,7 @@ from task_sharding.test.utils import (
 )
 
 
-class TaskShardingTests__SingleConsumerStepFailed(TestCase):
+class TaskShardingTests__SingleConsumerTaskFailed(TestCase):
     async def setUpAsync(self):
         application = create_application()
         self.controller = ApplicationCommunicator(application, {"type": "channel", "channel": "controller"})
@@ -27,14 +27,14 @@ class TaskShardingTests__SingleConsumerStepFailed(TestCase):
         await self.consumer.disconnect()
         await proxy_message_from_channel_to_communicator("controller", self.controller)
 
-    async def test__when_one_consumer_connected__and_single_schema_step_is_failed__expect_build_instruction_resent(
+    async def test__when_one_consumer_connected__and_single_schema_task_is_failed__expect_build_instruction_resent(
         self,
     ):
         """
         GIVEN a freshly instantiated TaskShardingController.
-        WHEN a consumer connects and sends an INIT message with a single step,
+        WHEN a consumer connects and sends an INIT message with a single task,
           AND the server sends a build instruction message to the consumer,
-          AND the consumer subsequently sends a failed step message.
+          AND the consumer subsequently sends a failed task message.
         EXPECT the server to send the same build instruction message to the consumer.
         """
 
@@ -60,7 +60,7 @@ class TaskShardingTests__SingleConsumerStepFailed(TestCase):
         await self.tearDownAsync()
 
 
-class TaskShardingTests__SingleConsumerStepAbandoned(TestCase):
+class TaskShardingTests__SingleConsumerTaskAbandoned(TestCase):
     async def setUpAsync(self):
         application = create_application()
         self.controller = ApplicationCommunicator(application, {"type": "channel", "channel": "controller"})
@@ -71,10 +71,10 @@ class TaskShardingTests__SingleConsumerStepAbandoned(TestCase):
         await self.consumer.disconnect()
         await proxy_message_from_channel_to_communicator("controller", self.controller)
 
-    async def test__when_one_consumer_connected__and_single_schema_step_is_abandoned__expect_schema_is_abandoned(self):
+    async def test__when_one_consumer_connected__and_single_schema_task_is_abandoned__expect_schema_is_abandoned(self):
         """
         GIVEN a freshly instantiated TaskShardingController.
-        WHEN a consumer connects and sends an INIT message with a single step,
+        WHEN a consumer connects and sends an INIT message with a single task,
           AND the server sends a build instruction message to the consumer,
           AND the consumer subsequently disconnects.
         EXPECT the server to abandon the schema.
@@ -102,7 +102,7 @@ class TaskShardingTests__SingleConsumerStepAbandoned(TestCase):
         self.assertEqual(0, total_running_schema_instances)
 
 
-class TaskShardingTests__MultipleConsumerStepAbandoned(TestCase):
+class TaskShardingTests__MultipleConsumerTaskAbandoned(TestCase):
     async def setUpAsync(self):
         application = create_application()
         self.controller = ApplicationCommunicator(application, {"type": "channel", "channel": "controller"})
@@ -111,15 +111,15 @@ class TaskShardingTests__MultipleConsumerStepAbandoned(TestCase):
         self.consumer2 = WebsocketCommunicator(application, "/ws/api/1/1/")
         await self.consumer2.connect()
 
-    async def test__when_two_consumers_connected__and_schema_step_is_abandoned__expect_abandoned_schema_step_to_be_assigned_to_other_consumer(
+    async def test__when_two_consumers_connected__and_schema_task_is_abandoned__expect_abandoned_schema_task_to_be_assigned_to_other_consumer(
         self,
     ):
         """
         GIVEN a freshly instantiated TaskShardingController.
-        WHEN two consumers connect and send an INIT message with the same config and two steps,
+        WHEN two consumers connect and send an INIT message with the same config and two tasks,
           AND the server sends a different build instruction message to each consumer,
-          AND one consumer subsequently disconnects during the step.
-        EXPECT the abandoned step to be assigned to the remaining consumer.
+          AND one consumer subsequently disconnects during the task.
+        EXPECT the abandoned task to be assigned to the remaining consumer.
         """
 
         await self.setUpAsync()
@@ -129,29 +129,29 @@ class TaskShardingTests__MultipleConsumerStepAbandoned(TestCase):
         await send_message_between_communicators(self.consumer1, self.controller, client_init_msg)
 
         # Assert the controller sent the correct build instruction to the consumer
-        expected_build_instruction_msg_step_1 = create_default_build_instruction_message("1")
+        expected_build_instruction_msg_task_1 = create_default_build_instruction_message("1")
         actual_build_instruction_msg = await self.consumer1.receive_from()
-        self.assertDictEqual(expected_build_instruction_msg_step_1, json.loads(actual_build_instruction_msg))
+        self.assertDictEqual(expected_build_instruction_msg_task_1, json.loads(actual_build_instruction_msg))
 
         # Send client init message to controller
         await send_message_between_communicators(self.consumer2, self.controller, client_init_msg)
 
         # Assert the controller sent the correct build instruction to the consumer
-        expected_build_instruction_msg_step_0 = create_default_build_instruction_message()
+        expected_build_instruction_msg_task_0 = create_default_build_instruction_message()
         actual_build_instruction_msg = await self.consumer2.receive_from()
-        self.assertDictEqual(expected_build_instruction_msg_step_0, json.loads(actual_build_instruction_msg))
+        self.assertDictEqual(expected_build_instruction_msg_task_0, json.loads(actual_build_instruction_msg))
 
         # Disconnect consumer1
         await self.consumer1.disconnect()
         await proxy_message_from_channel_to_communicator("controller", self.controller)
 
         # Send task complete message to controller
-        step_2_task_complete_msg = create_default_task_complete_message()
-        await send_message_between_communicators(self.consumer2, self.controller, step_2_task_complete_msg)
+        task_2_task_complete_msg = create_default_task_complete_message()
+        await send_message_between_communicators(self.consumer2, self.controller, task_2_task_complete_msg)
 
         # Assert the controller sent the correct build instruction to the consumer
         actual_build_instruction_msg = await self.consumer2.receive_from()
-        self.assertDictEqual(expected_build_instruction_msg_step_1, json.loads(actual_build_instruction_msg))
+        self.assertDictEqual(expected_build_instruction_msg_task_1, json.loads(actual_build_instruction_msg))
 
         await self.consumer2.disconnect()
         await proxy_message_from_channel_to_communicator("controller", self.controller)


### PR DESCRIPTION
In order to keep the naming consistent.